### PR TITLE
Fix Sipgate Softphone recipes

### DIFF
--- a/Sipgate/Sipgate.download.recipe
+++ b/Sipgate/Sipgate.download.recipe
@@ -21,7 +21,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>https://sipgate-whitelabel-live.s3.eu-central-1.amazonaws.com/sipgate.dmg</string>
+				<string>https://sipgate-desktop-app.s3.eu-central-1.amazonaws.com/sipgate-softphone.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -34,7 +34,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/sipgate.app</string>
+				<string>%pathname%/sipgate softphone.app</string>
 				<key>requirement</key>
 				<string>identifier "com.sipgate.desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = K4L4M6DD76</string>
 			</dict>
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/sipgate.app/Contents/Info.plist</string>
+				<string>%pathname%/sipgate softphone.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Sipgate/Sipgate.install.recipe
+++ b/Sipgate/Sipgate.install.recipe
@@ -28,7 +28,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>sipgate.app</string>
+						<string>sipgate softphone.app</string>
 					</dict>
 				</array>
 			</dict>


### PR DESCRIPTION
This PR modifies the Sipgate recipes with an updated download URL and app name.

Verbose recipe output run:

```
% autopkg run -vvq 'Sipgate/Sipgate.download.recipe'
Processing Sipgate/Sipgate.download.recipe...
WARNING: Sipgate/Sipgate.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'sipgate.dmg',
           'url': 'https://sipgate-desktop-app.s3.eu-central-1.amazonaws.com/sipgate-softphone.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.jannheider.download.sipgate/downloads/sipgate.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.jannheider.download.sipgate/downloads/sipgate.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.sipgate/downloads/sipgate.dmg/sipgate '
                         'softphone.app',
           'requirement': 'identifier "com.sipgate.desktop" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'K4L4M6DD76'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jannheider.download.sipgate/downloads/sipgate.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.L0gizx/sipgate softphone.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.L0gizx/sipgate softphone.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.L0gizx/sipgate softphone.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.sipgate/downloads/sipgate.dmg/sipgate '
                               'softphone.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jannheider.download.sipgate/downloads/sipgate.dmg
Versioner: Found version 1.17.19 in file ~/Library/AutoPkg/Cache/com.github.jannheider.download.sipgate/downloads/sipgate.dmg/sipgate softphone.app/Contents/Info.plist
{'Output': {'version': '1.17.19'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jannheider.download.sipgate/receipts/Sipgate.download-receipt-20241226-183117.plist

Nothing downloaded, packaged or imported.
```
