### PR TITLE
Make RustDesk recipes runnable by default

### DIFF
--- a/RustDesk/RustDesk.download.recipe
+++ b/RustDesk/RustDesk.download.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of RustDesk.</string>
+	<string>Downloads the latest version of RustDesk.
+	
+Valid values for ARCH include:
+- "aarch64" (default, Apple Silicon)
+- "x86_64" (Intel)
+</string>
 	<key>Identifier</key>
 	<string>com.github.jannheider.download.RustDesk</string>
 	<key>Input</key>
@@ -11,7 +16,7 @@
 		<key>NAME</key>
 		<string>RustDesk</string>
 		<key>ARCH</key>
-		<string></string>
+		<string>aarch64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>2.3</string>

--- a/RustDesk/RustDesk.munki.recipe
+++ b/RustDesk/RustDesk.munki.recipe
@@ -4,10 +4,13 @@
 <dict>
 	<key>Comment</key>
 	<string>=== Info ===
-		Make one munki override for ARM and Intel, then change ARCH as you need.
-		aarch64 (Apple Silicon) or x86_64 (Intel)
-		also change supported_architectures as you need.
-		Apple Silicon is here the default
+Make one munki override for ARM and Intel, then change ARCH as you need.
+
+Valid values for ARCH include:
+- "aarch64" (default, Apple Silicon)
+- "x86_64" (Intel)
+
+also change supported_architectures as you need.
 	</string>
 	<key>Description</key>
 	<string>Downloads the latest version of RustDesk and imports it into Munki.</string>
@@ -19,8 +22,6 @@
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>RustDesk</string>
-		<key>ARCH</key>
-		<string>aarch64</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>


### PR DESCRIPTION
This recipe adds a default ARCH value and updates RustDesk recipe descriptions to clarify what values can be used.

Verbose recipe run output with default (Apple Silicon) architecture:

```
% autopkg run -vvq 'RustDesk/RustDesk.download.recipe'
Processing RustDesk/RustDesk.download.recipe...
WARNING: RustDesk/RustDesk.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*-aarch64\\.dmg$',
           'github_repo': 'rustdesk/rustdesk'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '.*-aarch64\.dmg$' among asset(s): rustdesk-1.3.6-0-x86_64.pkg.tar.zst, rustdesk-1.3.6-0.aarch64-suse.rpm, rustdesk-1.3.6-0.aarch64.rpm, rustdesk-1.3.6-0.x86_64-suse.rpm, rustdesk-1.3.6-0.x86_64.rpm, rustdesk-1.3.6-aarch64-signed.apk, rustdesk-1.3.6-aarch64.AppImage, rustdesk-1.3.6-aarch64.deb, rustdesk-1.3.6-aarch64.dmg, rustdesk-1.3.6-aarch64.flatpak, rustdesk-1.3.6-armv7-sciter.deb, rustdesk-1.3.6-armv7-signed.apk, rustdesk-1.3.6-universal-signed.apk, rustdesk-1.3.6-unsigned.tar.gz, rustdesk-1.3.6-x86-sciter.exe, rustdesk-1.3.6-x86_64-sciter.deb, rustdesk-1.3.6-x86_64-sciter.flatpak, rustdesk-1.3.6-x86_64-signed.apk, rustdesk-1.3.6-x86_64.AppImage, rustdesk-1.3.6-x86_64.deb, rustdesk-1.3.6-x86_64.dmg, rustdesk-1.3.6-x86_64.exe, rustdesk-1.3.6-x86_64.flatpak, rustdesk-1.3.6-x86_64.msi
GitHubReleasesInfoProvider: Selected asset 'rustdesk-1.3.6-aarch64.dmg' from release '1.3.6'
{'Output': {'asset_created_at': '2024-12-22T03:10:21Z',
            'asset_url': 'https://api.github.com/repos/rustdesk/rustdesk/releases/assets/215047079',
            'release_notes': '![image](https://github.com/rustdesk/rustdesk/assets/71636191/83754a64-31b8-47f0-8570-da22207759a9)\r\n'
[...snip...]
            'url': 'https://github.com/rustdesk/rustdesk/releases/download/1.3.6/rustdesk-1.3.6-aarch64.dmg',
            'version': '1.3.6'}}
URLDownloader
{'Input': {'filename': 'RustDesk-1.3.6-aarch64.dmg',
           'url': 'https://github.com/rustdesk/rustdesk/releases/download/1.3.6/rustdesk-1.3.6-aarch64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 22 Dec 2024 03:10:22 GMT
URLDownloader: Storing new ETag header: "0x8DD22362CA898A5"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-aarch64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD22362CA898A5"',
            'last_modified': 'Sun, 22 Dec 2024 03:10:22 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-aarch64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-aarch64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-aarch64.dmg/RustDesk.app',
           'requirement': 'identifier "com.carriez.rustdesk" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'HZF9JMC8YN'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-aarch64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.24TouJ/RustDesk.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.24TouJ/RustDesk.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.24TouJ/RustDesk.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-aarch64.dmg/RustDesk.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-aarch64.dmg
Versioner: Found version 1.3.6 in file ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-aarch64.dmg/RustDesk.app/Contents/Info.plist
{'Output': {'version': '1.3.6'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/receipts/RustDesk.download-receipt-20241226-182500.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-aarch64.dmg
```

Verbose recipe run output with Intel architecture:

```
% autopkg run -vvq 'RustDesk/RustDesk.download.recipe' -k ARCH=x86_64
Processing RustDesk/RustDesk.download.recipe...
WARNING: RustDesk/RustDesk.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*-x86_64\\.dmg$',
           'github_repo': 'rustdesk/rustdesk'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '.*-x86_64\.dmg$' among asset(s): rustdesk-1.3.6-0-x86_64.pkg.tar.zst, rustdesk-1.3.6-0.aarch64-suse.rpm, rustdesk-1.3.6-0.aarch64.rpm, rustdesk-1.3.6-0.x86_64-suse.rpm, rustdesk-1.3.6-0.x86_64.rpm, rustdesk-1.3.6-aarch64-signed.apk, rustdesk-1.3.6-aarch64.AppImage, rustdesk-1.3.6-aarch64.deb, rustdesk-1.3.6-aarch64.dmg, rustdesk-1.3.6-aarch64.flatpak, rustdesk-1.3.6-armv7-sciter.deb, rustdesk-1.3.6-armv7-signed.apk, rustdesk-1.3.6-universal-signed.apk, rustdesk-1.3.6-unsigned.tar.gz, rustdesk-1.3.6-x86-sciter.exe, rustdesk-1.3.6-x86_64-sciter.deb, rustdesk-1.3.6-x86_64-sciter.flatpak, rustdesk-1.3.6-x86_64-signed.apk, rustdesk-1.3.6-x86_64.AppImage, rustdesk-1.3.6-x86_64.deb, rustdesk-1.3.6-x86_64.dmg, rustdesk-1.3.6-x86_64.exe, rustdesk-1.3.6-x86_64.flatpak, rustdesk-1.3.6-x86_64.msi
GitHubReleasesInfoProvider: Selected asset 'rustdesk-1.3.6-x86_64.dmg' from release '1.3.6'
{'Output': {'asset_created_at': '2024-12-22T03:14:13Z',
            'asset_url': 'https://api.github.com/repos/rustdesk/rustdesk/releases/assets/215047665',
            'release_notes': '![image](https://github.com/rustdesk/rustdesk/assets/71636191/83754a64-31b8-47f0-8570-da22207759a9)\r\n'
[...snip...]
            'url': 'https://github.com/rustdesk/rustdesk/releases/download/1.3.6/rustdesk-1.3.6-x86_64.dmg',
            'version': '1.3.6'}}
URLDownloader
{'Input': {'filename': 'RustDesk-1.3.6-x86_64.dmg',
           'url': 'https://github.com/rustdesk/rustdesk/releases/download/1.3.6/rustdesk-1.3.6-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 22 Dec 2024 03:14:15 GMT
URLDownloader: Storing new ETag header: "0x8DD2236B727F28C"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-x86_64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD2236B727F28C"',
            'last_modified': 'Sun, 22 Dec 2024 03:14:15 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-x86_64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-x86_64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-x86_64.dmg/RustDesk.app',
           'requirement': 'identifier "com.carriez.rustdesk" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'HZF9JMC8YN'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-x86_64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.7vLA8Q/RustDesk.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.7vLA8Q/RustDesk.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.7vLA8Q/RustDesk.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-x86_64.dmg/RustDesk.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-x86_64.dmg
Versioner: Found version 1.3.6 in file ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-x86_64.dmg/RustDesk.app/Contents/Info.plist
{'Output': {'version': '1.3.6'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/receipts/RustDesk.download-receipt-20241226-182518.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jannheider.download.RustDesk/downloads/RustDesk-1.3.6-x86_64.dmg
```
