### PR TITLE
Fix Mailplane 4 recipes

### DIFF
--- a/Mailplane/Mailplane4.download.recipe
+++ b/Mailplane/Mailplane4.download.recipe
@@ -18,15 +18,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://update.mailplaneapp.com/mailplane_4.php</string>
-			</dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
 				<string>%NAME%.zip</string>
 				<key>url</key>


### PR DESCRIPTION
This PR removes the unnecessary SparkleUpdateInfoProvider process from the Mailplane download recipe. Without this step, the recipe works as expected.

Verbose recipe run output:

```
% autopkg run -vvq 'Mailplane/Mailplane4.download.recipe'
Processing Mailplane/Mailplane4.download.recipe...
WARNING: Mailplane/Mailplane4.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Mailplane.zip',
           'url': 'https://update.mailplaneapp.com/mailplane_4.php'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 05 Jul 2024 23:29:55 GMT
URLDownloader: Storing new ETag header: "4eb0b3f-668881f3-e134097ba0ff7ab5;;;"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/downloads/Mailplane.zip
{'Output': {'download_changed': True,
            'etag': '"4eb0b3f-668881f3-e134097ba0ff7ab5;;;"',
            'last_modified': 'Fri, 05 Jul 2024 23:29:55 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/downloads/Mailplane.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/downloads/Mailplane.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/downloads/Mailplane.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/Mailplane',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Mailplane.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/downloads/Mailplane.zip to ~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/Mailplane
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/Mailplane/Mailplane.app',
           'requirement': 'identifier "com.mailplaneapp.Mailplane3" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'D2D2E3WLFW'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/Mailplane/Mailplane.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/Mailplane/Mailplane.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/Mailplane/Mailplane.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/Mailplane/Mailplane.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 4.3.11 in file ~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/Mailplane/Mailplane.app/Contents/Info.plist
{'Output': {'version': '4.3.11'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/receipts/Mailplane4.download-receipt-20241226-181803.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jannheider.download.Mailplane/downloads/Mailplane.zip
```

