### PR TITLE
Deprecate DrawThings recipes

### DIFF
--- a/DrawThings/DrawThings.download.recipe
+++ b/DrawThings/DrawThings.download.recipe
@@ -21,6 +21,15 @@
 	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>DrawThings is now only available from te Mac App Store (https://apps.apple.com/us/app/draw-things-ai-generation/id6444050820). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
        <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
This PR deprecates the DrawThings recipes, as the software is now only available from the Mac App Store.
