### PR TITLE
Fix Awork recipes and add default ARCH value

### DIFF
--- a/awork/awork.download.recipe
+++ b/awork/awork.download.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of awork.</string>
+	<string>Downloads the latest version of awork.
+	
+Valid values for ARCH include:
+- "x64" (default, Intel)
+- "arm64" (Apple Silicon)
+</string>
 	<key>Identifier</key>
 	<string>com.github.jannheider.download.awork</string>
 	<key>Input</key>
@@ -11,7 +16,7 @@
 		<key>NAME</key>
 		<string>awork</string>
 		<key>ARCH</key>
-		<string></string>
+		<string>x64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -23,7 +28,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>https://api.awork.io/api/v1/versions/electron/releases/download?platform=mac_%ARCH%</string>
+				<string>https://api.awork.com/api/v1/versions/electron/releases/download?platform=mac_%ARCH%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/awork/awork.munki.recipe
+++ b/awork/awork.munki.recipe
@@ -4,9 +4,13 @@
 <dict>
 	<key>Comment</key>
 	<string>=== Info ===
-		Make one munki override for ARM and Intel, then change ARCH as you need.
-		arm64 (M1) or x64 (Intel)
-		also change supported_architectures as you need.
+Make one munki override for ARM and Intel, then change ARCH as you need.
+
+Valid values for ARCH include:
+- "x64" (default, Intel)
+- "arm64" (Apple Silicon)
+
+Also change supported_architectures as you need.
 	</string>
 	<key>Description</key>
 	<string>Downloads the latest version of awork and imports it into Munki.</string>
@@ -18,8 +22,6 @@
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>awork</string>
-		<key>ARCH</key>
-		<string>arm64</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -38,7 +40,7 @@
 			<true/>
 			<key>supported_architectures</key>
 			<array>
-				<string>arm64</string>
+				<string>x86_64</string>
 			</array>
 		</dict>
 	</dict>


### PR DESCRIPTION
This PR updates the host used to download Awork for Mac. It also adds a default ARCH value, as running this recipe without one results in an error. Finally, I've added clarification in the description about what values are acceptable for ARCH.

```
% autopkg run -vvq 'awork/awork.download.recipe'
Processing awork/awork.download.recipe...
WARNING: awork/awork.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'awork.dmg',
           'url': 'https://api.awork.com/api/v1/versions/electron/releases/download?platform=mac_x64'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jannheider.download.awork/downloads/awork.dmg
{'Output': {'download_changed': True,
            'pathname': '~/Library/AutoPkg/Cache/com.github.jannheider.download.awork/downloads/awork.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.awork/downloads/awork.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.awork/downloads/awork.dmg/awork.app',
           'requirement': 'identifier "com.electron.awork" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'G47S2MC5J7'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jannheider.download.awork/downloads/awork.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.toC0mJ/awork.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.toC0mJ/awork.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.toC0mJ/awork.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jannheider.download.awork/downloads/awork.dmg/awork.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jannheider.download.awork/downloads/awork.dmg
Versioner: Found version 3.0.9 in file ~/Library/AutoPkg/Cache/com.github.jannheider.download.awork/downloads/awork.dmg/awork.app/Contents/Info.plist
{'Output': {'version': '3.0.9'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jannheider.download.awork/receipts/awork.download-receipt-20241226-180902.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jannheider.download.awork/downloads/awork.dmg
```
