### PR TITLE
Deprecate 1Password recipes

### DIFF
--- a/AgileBits/1PasswordLatest.download.recipe
+++ b/AgileBits/1PasswordLatest.download.recipe
@@ -18,6 +18,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to one of the many other 1Password recipes available in the autopkg org. Some alternatives are in the dataJAR-recipes, nstrauss-recipes, or hjuutilainen-recipes repos. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>


### PR DESCRIPTION
The 1Password recipes are redundant with several others across the AutoPkg org. In order to reduce confusion by AutoPkg users and maintenance effort by recipe maintainers and AutoPkg org admins, this pull request deprecates the 1Password recipes in this repo and points users elsewhere.
