### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/MIBBrowserFree/MIBBrowserFree.download.recipe
+++ b/MIBBrowserFree/MIBBrowserFree.download.recipe
@@ -21,7 +21,7 @@
 				<key>filename</key>
 				<string>%NAME%.pkg</string>
 				<key>url</key>
-				<string>http://www.ireasoning.com/download/mibfree/mibbrowser.pkg</string>
+				<string>https://www.ireasoning.com/download/mibfree/mibbrowser.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._