### PR TITLE
Change GoogleWebDesigner parent recipe to peshay's download

### DIFF
--- a/GoogleWebDesigner/GoogleWebDesigner.download.recipe
+++ b/GoogleWebDesigner/GoogleWebDesigner.download.recipe
@@ -12,9 +12,18 @@
 		<string>Google Web Designer</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the GoogleWebDesigner recipes in the peshay-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/GoogleWebDesigner/GoogleWebDesigner.install.recipe
+++ b/GoogleWebDesigner/GoogleWebDesigner.install.recipe
@@ -14,7 +14,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.jannheider.download.GoogleWebDesigner</string>
+	<string>com.github.peshay.download.GoogleWebDesigner</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/GoogleWebDesigner/GoogleWebDesigner.munki.recipe
+++ b/GoogleWebDesigner/GoogleWebDesigner.munki.recipe
@@ -33,7 +33,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.jannheider.download.GoogleWebDesigner</string>
+	<string>com.github.peshay.download.GoogleWebDesigner</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/GoogleWebDesigner/GoogleWebDesigner.pkg.recipe
+++ b/GoogleWebDesigner/GoogleWebDesigner.pkg.recipe
@@ -14,7 +14,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.jannheider.download.GoogleWebDesigner</string>
+	<string>com.github.peshay.download.GoogleWebDesigner</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The GoogleWebDesigner download recipe in this repo is similar in function to the earlier-created one in peshay-recipes. This PR adjusts the munki, install, and pkg recipes to use peshay's download as a parent.

This consolidation will help simplify search results and lower maintenance effort. Thank you!

Modified pkg recipe verbose output:

```
% autopkg run -vvq 'jannheider-recipes/GoogleWebDesigner/GoogleWebDesigner.pkg.recipe'
Processing jannheider-recipes/GoogleWebDesigner/GoogleWebDesigner.pkg.recipe...
WARNING: jannheider-recipes/GoogleWebDesigner/GoogleWebDesigner.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://dl.google.com/webdesigner/mac/shell/googlewebdesigner_mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 22 Jul 2025 16:38:02 GMT
URLDownloader: Storing new ETag header: "47fce8f"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg
{'Output': {'download_changed': True,
            'etag': '"47fce8f"',
            'last_modified': 'Tue, 22 Jul 2025 16:38:02 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg
AppDmgVersioner: BundleID: com.google.WebDesigner
AppDmgVersioner: Version: 14.2.4.0
{'Output': {'app_name': 'Google Web Designer.app',
            'bundleid': 'com.google.WebDesigner',
            'version': '14.2.4.0'}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg/*.app',
           'requirement': 'identifier "com.google.WebDesigner" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'EQHXZ8M8AV'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.5VmJVw/Google Web Designer.app' matched from globbed '/private/tmp/dmg.5VmJVw/*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.5VmJVw/Google Web Designer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.5VmJVw/Google Web Designer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.5VmJVw/Google Web Designer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'bundleid': 'com.google.WebDesigner', 'version': '14.2.4.0'}}
AppPkgCreator: No value supplied for version_key, setting default value of: CFBundleShortVersionString
AppPkgCreator: No value supplied for force_pkg_build, setting default value of: False
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg
AppPkgCreator: Using path '/private/tmp/dmg.4KITOP/Google Web Designer.app' matched from globbed '/private/tmp/dmg.4KITOP/*.app'.
AppPkgCreator: Copied /private/tmp/dmg.4KITOP/Google Web Designer.app to ~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/payload/Applications/Google Web Designer.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.google.WebDesigner',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/Google '
                                                                    'Web '
                                                                    'Designer-14.2.4.0.pkg',
                                                        'version': '14.2.4.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '14.2.4.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/receipts/GoogleWebDesigner.pkg-receipt-20251109-122727.plist

The following new items were downloaded:
    Download Path                                                                                                        
    -------------                                                                                                        
    ~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg  

The following packages were built:
    Identifier              Version   Pkg Path                                                                                                          
    ----------              -------   --------                                                                                                          
    com.google.WebDesigner  14.2.4.0  ~/Library/AutoPkg/Cache/com.github.jannheider.pkg.GoogleWebDesigner/Google Web Designer-14.2.4.0.pkg
```